### PR TITLE
Do not rely on ENV['ANSIBLE_REMOTE_USER']

### DIFF
--- a/vagrant/bootstrap_user.rb
+++ b/vagrant/bootstrap_user.rb
@@ -1,7 +1,5 @@
 class Vagrant::BoostrapUser
-  def initialize(vm, remote_user: ENV['ANSIBLE_REMOTE_USER'])
-    raise "You need to set ANSIBLE_REMOTE_USER in your shell" unless remote_user
-
+  def initialize(vm, remote_user:)
     @vm          = vm
     @remote_user = remote_user
 


### PR DESCRIPTION
Relying on the ANSIBLE_REMOTE_USER expects every developer to actually
set that user in her/his setup. When we instead rely on the currently
logged in user (using `whoami`) we do not need to configure that.
